### PR TITLE
feat: 게시글 작성 사진 맞춤 / 사진 미리보기 구현 / 게시글 수정 페이지 파일 추가 / 상세 페이지 일부 수정

### DIFF
--- a/posts/static/posts/detail.css
+++ b/posts/static/posts/detail.css
@@ -230,7 +230,7 @@ body {
 }
 
 .type-time,
-.place-status-age {
+.place-condition-age {
   margin: 5px 0;
 }
 
@@ -259,17 +259,13 @@ body {
 }
 
 .time,
-.place-status-age {
+.place-condition-age {
   color: #8a8a8a;
 }
 
-.place-status-age,
+.place-condition-age,
 .description {
   font-size: 15px;
-}
-
-.description {
-  white-space: pre-line;
 }
 
 .sold-out {

--- a/posts/static/posts/js/post.js
+++ b/posts/static/posts/js/post.js
@@ -1,6 +1,7 @@
 const mainForm = document.querySelector(".main-form");
 const photoInput = document.getElementById("photo-input");
 const photoErr = document.getElementById("photo-err");
+const photoStatus = document.querySelector(".photo-input-status");
 const category = document.getElementById("category");
 const categorySelected = document.querySelector(".category-selected");
 const place = document.getElementById("place");
@@ -13,18 +14,51 @@ const tradeTypes = document.getElementsByName("trade_type");
 const typeLabels = document.querySelectorAll(".btn-label");
 const typeErr = document.getElementById("type-err");
 
-// 사진 3장 넘어가면 첨부 못하게
+// photo-input에서 여러 번에 걸쳐서 사진 선택할 수 있도록 전체 배열 선언하고 시작
+let allPhotos = [];
+
+// 사진 미리보기 함수
+function renderPreview(photos) {
+  const previews = document.querySelectorAll(".photo-preview");
+  const unknowns = document.querySelectorAll(".photo-preview-unknown");
+
+  // 초기화
+  previews.forEach((preview) => preview.classList.add("hidden"));
+  unknowns.forEach((unknown) => unknown.classList.remove("hidden"));
+
+  photos.forEach((photo, i) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const previewBox = previews[i];
+      const previewImg = previewBox.querySelector("img");
+      previewImg.src = e.target.result;
+
+      previewBox.classList.remove("hidden");
+      unknowns[i].classList.add("hidden");
+    };
+    reader.readAsDataURL(photo);
+  });
+}
+
 photoInput.addEventListener("change", () => {
   const photos = Array.from(photoInput.files); // photo-input에 올라간 사진 파일 배열
-  if (photos.length > 3) {
+  // 사진 3장 넘어가면 첨부 못하게
+  if (allPhotos.length + photos.length > 3) {
     alert("사진은 최대 3장까지 업로드할 수 있습니다.");
     photoInput.value = "";
     return;
   }
 
-  if (photos.length >= 1 && photos.length <= 3) {
+  allPhotos = allPhotos.concat(photos); // 여러 번에 걸쳐서 사진 선택 가능
+  photoInput.value = ""; // 같은 파일도 다시 선택할 수 있도록 초기화
+
+  if (allPhotos.length >= 1) {
     photoErr.classList.add("hidden");
   }
+
+  photoStatus.textContent = `${allPhotos.length}/3`;
+
+  renderPreview(allPhotos); // 어떤 사진인지 확인
 });
 
 category.addEventListener("change", () => {
@@ -130,42 +164,66 @@ document.addEventListener("click", () => {
 
 // 제출 시 필수항목 확인
 mainForm.addEventListener("submit", (e) => {
-  const photos = Array.from(photoInput.files);
-  if (photos.length < 1) {
-    e.preventDefault();
+  let valid = true;
+
+  if (allPhotos.length < 1) {
+    valid = false;
     photoErr.classList.remove("hidden");
   }
 
   if (!category.value) {
-    e.preventDefault();
+    valid = false;
     categorySelected.style.borderColor = "var(--color-red)";
   }
 
   const placeValue = place.value.trim();
   if (!placeValue || placeValue.length > 12) {
-    e.preventDefault();
+    valid = false;
     place.style.borderColor = "var(--color-red)";
     placeErr.classList.remove("hidden");
   }
 
   const titleValue = title.value.trim();
   if (!titleValue || titleValue.length > 12) {
-    e.preventDefault();
+    valid = false;
     title.style.borderColor = "var(--color-red)";
     titleErr.classList.remove("hidden");
   }
 
   const descValue = desc.value.trim();
   if (!descValue || descValue.length > 200) {
-    e.preventDefault();
+    valid = false;
     desc.style.borderColor = "var(--color-red)";
     descErr.classList.remove("hidden");
   }
 
   if (!tradeTypes[0].checked && !tradeTypes[1].checked) {
+    valid = false;
     typeLabels.forEach((label) => {
       label.style.borderColor = "var(--color-red)";
       typeErr.classList.remove("hidden");
+    });
+  }
+
+  if (!valid) {
+    e.preventDefault();
+  }
+
+  // 사진 formData.append로 순서 맞춰서 보냄
+  if (valid) {
+    e.preventDefault();
+    const formData = new FormData(mainForm);
+    formData.delete("photos"); // 중복 제거
+    allPhotos.forEach((photo) => formData.append("photos", photo));
+    photoInput.value = ""; // 초기화
+
+    fetch(mainForm.action, {
+      method: "POST",
+      body: formData,
+    }).then((res) => {
+      if (res.redirected) {
+        window.location.href = res.url;
+      }
     });
   }
 });

--- a/posts/static/posts/post.css
+++ b/posts/static/posts/post.css
@@ -76,6 +76,7 @@ body {
   display: flex;
   justify-content: center;
   align-items: center;
+  cursor: pointer;
 }
 
 #photo-input,
@@ -86,6 +87,7 @@ body {
 
 #photo-input-label img {
   margin: 5px 0;
+  cursor: pointer;
 }
 
 .photo-input-status {
@@ -95,12 +97,33 @@ body {
   display: flex;
   justify-content: center;
   align-items: center;
+  cursor: pointer;
 }
 
-.photo-preview {
+.photo-slot {
+  position: relative;
   width: 60px;
   height: 60px;
   border-radius: 8px;
+}
+
+.photo-preview,
+.photo-preview-unknown {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+}
+
+.photo-preview img {
+  width: 60px;
+  height: 60px;
+  border-radius: 8px;
+}
+
+.photo-preview-unknown {
   display: flex;
   justify-content: center;
   align-items: center;

--- a/posts/static/posts/post.css
+++ b/posts/static/posts/post.css
@@ -77,6 +77,7 @@ body {
   justify-content: center;
   align-items: center;
   cursor: pointer;
+  -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
 }
 
 #photo-input,

--- a/posts/templates/posts/detail.html
+++ b/posts/templates/posts/detail.html
@@ -79,8 +79,13 @@ a<!DOCTYPE html>
             <!-- <div class="type exchange-type">교환</div> -->
             <div class="time">07/01 13:20</div>
           </div>
-          <div class="place-status-age">
-            거래 희망 장소 / 제품 상태 / 추천 월령
+          <div class="place place-condition-age">
+            <div class="dot"></div>
+            <span id="place">상계동 하나로 마트 앞</span>
+            <span>/</span>
+            <span id="condition">상태 양호</span>
+            <span>/</span>
+            <span id="age">7-8세 추천</span>
           </div>
           <div class="description">
             간단하게 입력된 설명 간단하게 입력된 설명 간단하게 입력된 설명

--- a/posts/templates/posts/modify.html
+++ b/posts/templates/posts/modify.html
@@ -1,0 +1,234 @@
+<!DOCTYPE html>
+{% load static %}
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dearbebe</title>
+    <link rel="stylesheet" href="{% static 'posts/common.css' %}" />
+    <link rel="stylesheet" href="{% static 'posts/post.css' %}" />
+    <script defer src="{% static 'posts/js/post.js' %}"></script>
+
+    <!--    <link rel="stylesheet" href="/posts/static/posts/common.css" />-->
+    <!--    <link rel="stylesheet" href="/posts/static/posts/post.css" />-->
+    <!--    <script defer src="/posts/static/posts/js/post.js"></script>-->
+  </head>
+  <body>
+    <div class="main-container">
+      <div class="header">
+        <a href="" class="back-btn">
+          <img src="{% static 'posts/images/back.svg' %}" alt="뒤로가기" />
+          <!--          <img src="/posts/static/posts/images/back.svg" alt="뒤로가기" />-->
+        </a>
+        <div class="header-title">글쓰기</div>
+        <p></p>
+      </div>
+      <form
+        method="POST"
+        action=""
+        class="main-form"
+        enctype="multipart/form-data"
+      >
+        {% csrf_token %}
+        <div class="photo-container">
+          <div class="photo-title">사진</div>
+          <div class="photo-box">
+            <div class="photo-select">
+              <label for="photo-input" id="photo-input-label">
+                <input
+                  type="file"
+                  accept="image/*"
+                  id="photo-input"
+                  name="photos"
+                  multiple
+                />
+                <img
+                  src="{% static 'posts/images/add.svg' %}"
+                  alt="사진 추가"
+                />
+                <!--                <img src="/posts/static/posts/images/add.svg" alt="사진 추가" />-->
+                <div class="photo-input-status">0/3</div>
+              </label>
+            </div>
+            <div class="photo-slot">
+              <!-- 고른 사진이 없을 때 -->
+              <div class="photo-preview-unknown">
+                <img
+                  src="{% static 'posts/images/image.svg' %}"
+                  alt="사진 없음"
+                />
+              </div>
+              <!-- 고른 사진이 있을 때 -->
+              <div class="photo-preview hidden">
+                <img src="#" alt="사진" />
+              </div>
+            </div>
+            <div class="photo-slot">
+              <!-- 고른 사진이 없을 때 -->
+              <div class="photo-preview-unknown">
+                <img
+                  src="{% static 'posts/images/image.svg' %}"
+                  alt="사진 없음"
+                />
+              </div>
+              <!-- 고른 사진이 있을 때 -->
+              <div class="photo-preview hidden">
+                <img src="#" alt="사진" />
+              </div>
+            </div>
+            <div class="photo-slot">
+              <!-- 고른 사진이 없을 때 -->
+              <div class="photo-preview-unknown">
+                <img
+                  src="{% static 'posts/images/image.svg' %}"
+                  alt="사진 없음"
+                />
+              </div>
+              <!-- 고른 사진이 있을 때 -->
+              <div class="photo-preview hidden">
+                <img src="#" alt="사진" />
+              </div>
+            </div>
+          </div>
+          <div class="error-msg hidden" id="photo-err">
+            사진을 1장 이상으로 등록해주세요.
+          </div>
+        </div>
+        <div class="category-container dropdown">
+          <!-- category value는 이 hidden input에 들어감 -->
+          <input
+            type="hidden"
+            id="category"
+            name="category"
+            class="hidden-input"
+            placeholder="카테고리"
+          />
+          <div class="selected category-selected">
+            <p>카테고리</p>
+            <img
+              src="{% static 'posts/images/arrow.svg' %}"
+              alt="드롭다운 버튼"
+            />
+            <!--            <img-->
+            <!--              src="/posts/static/posts/images/arrow.svg"-->
+            <!--              alt="드롭다운 버튼"-->
+            <!--            />-->
+          </div>
+          <div class="options hidden">
+            <!-- 각 item div의 textContent가 value로 들어감 (post.js 참고)-->
+            <div class="item">의류</div>
+            <div class="item">수유</div>
+            <div class="item">위생</div>
+            <div class="item">장난감</div>
+            <div class="item">기타</div>
+          </div>
+        </div>
+        <div class="place-container">
+          <label for="place" class="text-label">거래 희망 장소</label>
+          <div class="wrapper">
+            <input type="text" maxlength="12" id="place" name="place" />
+            <div class="limit">12자 이내</div>
+          </div>
+          <div class="error-msg hidden" id="place-err">
+            필수 입력 사항입니다.
+          </div>
+        </div>
+        <div class="title-container">
+          <label for="title" class="text-label">제목(용품명)</label>
+          <div class="wrapper">
+            <input type="text" maxlength="12" id="title" name="title" />
+            <div class="limit">12자 이내</div>
+          </div>
+          <div class="error-msg hidden" id="title-err">
+            필수 입력 사항입니다.
+          </div>
+        </div>
+        <div class="desc-container">
+          <label for="description" class="text-label">설명</label>
+          <div class="wrapper">
+            <textarea
+              name="description"
+              id="description"
+              maxlength="200"
+            ></textarea>
+            <div class="limit">200자 이내</div>
+          </div>
+          <div class="error-msg hidden" id="desc-err">
+            필수 입력 사항입니다.
+          </div>
+        </div>
+        <div class="type-container">
+          <div class="type-box">
+            <input type="radio" value="무료나눔" id="free" name="trade_type" />
+            <label for="free" class="btn-label">무료 나눔</label>
+            <input type="radio" value="교환" id="exchange" name="trade_type" />
+            <label for="exchange" class="btn-label">교환</label>
+          </div>
+          <div class="error-msg hidden" id="type-err">하나를 선택해주세요.</div>
+        </div>
+        <div class="condition-container dropdown">
+          <input
+            type="hidden"
+            id="condition"
+            name="condition"
+            class="hidden-input"
+            placeholder="제품 상태"
+          />
+          <div class="selected condition-selected">
+            <p>제품 상태</p>
+            <img
+              src="{% static 'posts/images/arrow.svg' %}"
+              alt="드롭다운 버튼"
+            />
+            <!--            <img-->
+            <!--              src="/posts/static/posts/images/arrow.svg"-->
+            <!--              alt="드롭다운 버튼"-->
+            <!--            />-->
+          </div>
+          <div class="options hidden">
+            <div class="item">새상품</div>
+            <div class="item">상태 양호</div>
+            <div class="item">사용감 있음(생활 기스/ 오염)</div>
+            <div class="item">사용감 많음(기능 정상)</div>
+          </div>
+        </div>
+        <div class="age-container dropdown">
+          <input
+            type="hidden"
+            id="age"
+            name="age"
+            class="hidden-input"
+            placeholder="추천 월령"
+          />
+          <div class="selected age-selected">
+            <p>추천 월령</p>
+            <img
+              src="{% static 'posts/images/arrow.svg' %}"
+              alt="드롭다운 버튼"
+            />
+            <!--            <img-->
+            <!--              src="/posts/static/posts/images/arrow.svg"-->
+            <!--              alt="드롭다운 버튼"-->
+            <!--            />-->
+          </div>
+          <div class="options hidden">
+            <div class="item">0~3개월</div>
+            <div class="item">3~6개월</div>
+            <div class="item">6~9개월</div>
+            <div class="item">9~12개월</div>
+            <div class="item">12~18개월</div>
+            <div class="item">18~24개월</div>
+            <div class="item">24~36개월</div>
+            <div class="item">4~5세</div>
+            <div class="item">6~7세</div>
+            <div class="item">8~10세</div>
+            <div class="item">10세 이상</div>
+          </div>
+        </div>
+        <div class="button-wrapper">
+          <button type="submit" class="submit-btn">수정 완료</button>
+        </div>
+      </form>
+    </div>
+  </body>
+</html>

--- a/posts/templates/posts/post.html
+++ b/posts/templates/posts/post.html
@@ -9,46 +9,85 @@
     <link rel="stylesheet" href="{% static 'posts/post.css' %}" />
     <script defer src="{% static 'posts/js/post.js' %}"></script>
 
-<!--    <link rel="stylesheet" href="/posts/static/posts/common.css" />-->
-<!--    <link rel="stylesheet" href="/posts/static/posts/post.css" />-->
-<!--    <script defer src="/posts/static/posts/js/post.js"></script>-->
+    <!--    <link rel="stylesheet" href="/posts/static/posts/common.css" />-->
+    <!--    <link rel="stylesheet" href="/posts/static/posts/post.css" />-->
+    <!--    <script defer src="/posts/static/posts/js/post.js"></script>-->
   </head>
   <body>
     <div class="main-container">
       <div class="header">
         <a href="" class="back-btn">
           <img src="{% static 'posts/images/back.svg' %}" alt="뒤로가기" />
-<!--          <img src="/posts/static/posts/images/back.svg" alt="뒤로가기" />-->
+          <!--          <img src="/posts/static/posts/images/back.svg" alt="뒤로가기" />-->
         </a>
         <div class="header-title">글쓰기</div>
         <p></p>
       </div>
-      <form method="POST" action="" class="main-form" enctype="multipart/form-data">
+      <form
+        method="POST"
+        action=""
+        class="main-form"
+        enctype="multipart/form-data"
+      >
         {% csrf_token %}
         <div class="photo-container">
           <div class="photo-title">사진</div>
           <div class="photo-box">
             <div class="photo-select">
               <label for="photo-input" id="photo-input-label">
-                <input type="file" accept="image/*" id="photo-input" name="photos" multiple />
-                <img src="{% static 'posts/images/add.svg' %}" alt="사진 추가" />
-<!--                <img src="/posts/static/posts/images/add.svg" alt="사진 추가" />-->
+                <input
+                  type="file"
+                  accept="image/*"
+                  id="photo-input"
+                  name="photos"
+                  multiple
+                />
+                <img
+                  src="{% static 'posts/images/add.svg' %}"
+                  alt="사진 추가"
+                />
+                <!--                <img src="/posts/static/posts/images/add.svg" alt="사진 추가" />-->
                 <div class="photo-input-status">0/3</div>
               </label>
             </div>
-            <div class="photo-preview">
+            <div class="photo-slot">
               <!-- 고른 사진이 없을 때 -->
-              <img src="{% static 'posts/images/image.svg' %}" alt="사진 없음" />
-<!--              <img src="/posts/static/posts/images/image.svg" alt="사진 없음" />-->
+              <div class="photo-preview-unknown">
+                <img
+                  src="{% static 'posts/images/image.svg' %}"
+                  alt="사진 없음"
+                />
+              </div>
               <!-- 고른 사진이 있을 때 -->
-              <!-- <img src="사진 링크" alt="사진" /> -->
+              <div class="photo-preview hidden">
+                <img src="#" alt="사진" />
+              </div>
             </div>
-            <div class="photo-preview">
-              <img src="{% static 'posts/images/image.svg' %}" alt="사진 없음" />
-<!--              <img src="/posts/static/posts/images/image.svg" alt="사진 없음" />-->
+            <div class="photo-slot">
+              <!-- 고른 사진이 없을 때 -->
+              <div class="photo-preview-unknown">
+                <img
+                  src="{% static 'posts/images/image.svg' %}"
+                  alt="사진 없음"
+                />
+              </div>
+              <!-- 고른 사진이 있을 때 -->
+              <div class="photo-preview hidden">
+                <img src="#" alt="사진" />
+              </div>
             </div>
-            <div class="photo-preview">
-              <img src="{% static 'posts/images/image.svg' %}" alt="사진 없음" />
+            <div class="photo-slot">
+              <!-- 고른 사진이 없을 때 -->
+              <div class="photo-preview-unknown">
+                <img
+                  src="{% static 'posts/images/image.svg' %}"
+                  alt="사진 없음"
+                />
+              </div>
+              <!-- 고른 사진이 있을 때 -->
+              <div class="photo-preview hidden">
+                <img src="#" alt="사진" />
+              </div>
             </div>
           </div>
           <div class="error-msg hidden" id="photo-err">
@@ -70,10 +109,10 @@
               src="{% static 'posts/images/arrow.svg' %}"
               alt="드롭다운 버튼"
             />
-<!--            <img-->
-<!--              src="/posts/static/posts/images/arrow.svg"-->
-<!--              alt="드롭다운 버튼"-->
-<!--            />-->
+            <!--            <img-->
+            <!--              src="/posts/static/posts/images/arrow.svg"-->
+            <!--              alt="드롭다운 버튼"-->
+            <!--            />-->
           </div>
           <div class="options hidden">
             <!-- 각 item div의 textContent가 value로 들어감 (post.js 참고)-->
@@ -141,10 +180,10 @@
               src="{% static 'posts/images/arrow.svg' %}"
               alt="드롭다운 버튼"
             />
-<!--            <img-->
-<!--              src="/posts/static/posts/images/arrow.svg"-->
-<!--              alt="드롭다운 버튼"-->
-<!--            />-->
+            <!--            <img-->
+            <!--              src="/posts/static/posts/images/arrow.svg"-->
+            <!--              alt="드롭다운 버튼"-->
+            <!--            />-->
           </div>
           <div class="options hidden">
             <div class="item">새상품</div>
@@ -167,10 +206,10 @@
               src="{% static 'posts/images/arrow.svg' %}"
               alt="드롭다운 버튼"
             />
-<!--            <img-->
-<!--              src="/posts/static/posts/images/arrow.svg"-->
-<!--              alt="드롭다운 버튼"-->
-<!--            />-->
+            <!--            <img-->
+            <!--              src="/posts/static/posts/images/arrow.svg"-->
+            <!--              alt="드롭다운 버튼"-->
+            <!--            />-->
           </div>
           <div class="options hidden">
             <div class="item">0~3개월</div>


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->


## ✅ 작업 내용
<!-- 작업에 대한 설명을 적어주세요 -->
- 게시글 작성 폼에서 사진이 순서대로 보내지지 않았던 문제 해결
(js에서 formData.append 활용.)
- 게시글 작성 폼에서 사진을 여러 번 선택해서 올리게 하도록 변경
- 게시글 작성 폼에서 photo-input에 올린 사진을 미리보기 할 수 있도록 구현
- 게시글 작성 폼 photo-input 터치 시 파랗게 뜨지 않도록 css 수정
- 게시글 수정 페이지 파일(modify.html) 추가
(기존 게시글 상세 페이지에서 하단 버튼만 '수정 완료'로 교체. 연동 시 필요할 것 같아 추가.)
- 게시글 상세 페이지 클래스명, css 등 일부 수정

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요하다면 스크린샷을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/cfb4f0cd-f014-4574-9e7f-bec961a3d50c)


## 💬 리뷰 참고 사항
<!-- 코드 리뷰 시 유의해야 할 점을 적어주세요 -->
서버에 잘 올라가는지는 확인을 못 했지만 미리보기가 제대로 되는 걸로 봐선 잘 될 것 같...습니다...! 그래도 문제가 발생하면 언제라도 꼭 말씀해주세요!!