### PR TITLE
style: 홈 화면 css 수정

### DIFF
--- a/home/static/home/home_main.css
+++ b/home/static/home/home_main.css
@@ -1,3 +1,7 @@
+h2 {
+  margin: 0;
+}
+
 .main-container {
   display: flex;
   flex-direction: column;
@@ -14,14 +18,18 @@
   display: flex;
   flex-direction: column;
   gap: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  height: 60px;
 }
 
 .top-bar {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 16px 0px;
   width: 100%;
+  gap: 20px;
 }
 
 /*  카테고리 버튼 */
@@ -31,6 +39,13 @@
   gap: 0;
   padding: 0;
   margin-top: 0px;
+  max-width: 430px;
+  width: calc(100% + 16px * 2); 
+  margin-left: -16px;
+  position: fixed;
+  top: 60px;
+  height: 30px;
+  background-color: #ffffff;
 }
 
 .category-btn {
@@ -42,9 +57,10 @@
   font-weight: 600;
   color: var(--color-deep-main);
   cursor: pointer;
-  padding: 6px 0;
   text-align: center;
   border-bottom: 1px solid var(--color-light-main);
+  box-sizing: border-box;
+  white-space: nowrap;
 }
 
 .category-btn.active {
@@ -56,9 +72,8 @@
 .search-box {
   display: flex;
   position: relative;
-  width: 290px;
   height: 34px;
-
+  width: 100%;
 }
 
 .top-location {
@@ -121,17 +136,20 @@
 .post-list {
   display: flex;
   flex-direction: column;
-  padding-top: 60px;
-  margin-bottom: 90px;
+  margin-top: 90px;
+  padding-bottom: 90px;
 }
 
 .item-card {
   display: flex;
   padding: 12px 16px;
   gap: 12px;
-  border-top: 1px solid #d9d9d9;
-  border-bottom: 1px solid #d9d9d9;
+  border-top: 1px solid var(--color-light-main);
   position: relative;
+}
+
+.item-card:last-child {
+  border-bottom: 1px solid var(--color-light-main);
 }
 
 .item-img {
@@ -157,7 +175,7 @@
   width: 88px;
   height: 17px;
   border-radius: 8.5px;
-  margin: 10px 10px;
+  margin: 10px 10px 10px 0;
   background-color: var(--color-deep-main);
   color: #fff;
 }
@@ -166,7 +184,7 @@
   width: 88px;
   height: 17px;
   border-radius: 8.5px;
-  margin: 10px 10px;
+  margin: 10px 10px 10px 0;
   background-color: var(--color-mint);
   color: #fff;
 }
@@ -213,7 +231,6 @@
 .title {
   font-size: 17px;
   font-weight: 600;
-  margin-top: 60px;
 }
 
 .plus_btn {
@@ -228,6 +245,7 @@
   z-index: 20;
   /* nav보다 위에 오게 */
   pointer-events: auto;
+  cursor: pointer;
 }
 
 .plus_bg {

--- a/home/static/home/home_nopost.css
+++ b/home/static/home/home_nopost.css
@@ -1,3 +1,7 @@
+h2 {
+  margin: 0;
+}
+
 .main-container {
     display: flex;
     flex-direction: column;
@@ -12,15 +16,18 @@
     /* 항상 위로 */
     padding: 12px 16px;
     box-sizing: border-box;
-
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    height: 60px;
 }
 
 .top-bar {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 12px 16px;
     width: 100%;
+    gap: 20px;
 }
 
 /*  카테고리 버튼 */
@@ -29,8 +36,14 @@
     justify-content: space-between;
     gap: 0;
     /* 버튼 간격 없이 균등 분배 */
-    padding: 8px 0;
     margin-top: 70px;
+    max-width: 430px;
+    width: calc(100% + 16px * 2); 
+    margin-left: -16px;
+    position: fixed;
+    top: 60px;
+    height: 30px;
+    background-color: #ffffff;
 }
 
 .category-btn {
@@ -42,10 +55,11 @@
     font-weight: 600;
     color: var(--color-deep-main);
     cursor: pointer;
-    padding: 6px 0;
     text-align: center;
     border-bottom: 1px solid var(--color-light-main);
-}
+    box-sizing: border-box;
+    white-space: nowrap;
+  }
 
 .category-btn.active {
     color: var(--color-deep-main);
@@ -56,9 +70,8 @@
 .search-box {
     display: flex;
     position: relative;
-    width: 290px;
     height: 34px;
-    margin-left: 20px;
+    width: 100%;
 }
 
 .top-location {
@@ -70,7 +83,7 @@
 
 .search-input {
     width: 100%;
-    padding: 8px 12px 8px 36px;
+    padding: 8px 12px 8px 60px;
     /* 왼쪽 패딩: 아이콘 공간 확보 */
     border: 1px solid #ccc;
     border-radius: 8px;
@@ -119,6 +132,7 @@
   line-height: 1.5;
    text-align: center;
 }
+
 .plus_btn {
   position: fixed;
   bottom: 100px; /* nav보다 살짝 위 */
@@ -128,6 +142,7 @@
   height: 52px;
   z-index: 20; /* nav보다 위에 오게 */
   pointer-events: auto;
+  cursor: pointer;
 }
 
 .plus_bg {

--- a/home/static/home/home_search.css
+++ b/home/static/home/home_search.css
@@ -1,3 +1,7 @@
+h2 {
+  margin: 0;
+}
+
 .main-container {
   display: flex;
   flex-direction: column;
@@ -12,14 +16,18 @@
   /* 항상 위로 */
   padding: 12px 16px 0px;
   box-sizing: border-box;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  height: 60px;
 }
 
 .top-bar {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0px 16px;
   width: 100%;
+  gap: 20px;
 }
 
 /*  카테고리 버튼 */
@@ -27,8 +35,13 @@
   display: flex;
   justify-content: space-between;
   gap: 0;
-  /* 버튼 간격 없이 균등 분배 */
-  padding: 8px 0;
+  max-width: 430px;
+  width: calc(100% + 16px * 2); 
+  margin-left: -16px;
+  position: fixed;
+  top: 60px;
+  height: 30px;
+  background-color: #ffffff;
 }
 
 .category-btn {
@@ -40,8 +53,9 @@
   font-weight: 600;
   color: var(--color-deep-main);
   cursor: pointer;
-  padding: 6px 0;
   text-align: center;
+  box-sizing: border-box;
+  white-space: nowrap;
   border-bottom: 1px solid var(--color-light-main);
 }
 
@@ -54,9 +68,8 @@
 .search-box {
   display: flex;
   position: relative;
-  width: 290px;
   height: 34px;
-  margin-left: 20px;
+  width: 100%;
 }
 
 .top-location {
@@ -68,8 +81,8 @@
 }
 
 .search-input {
-  width: 90%;
-  padding: 8px 12px 8px 30px;
+  width: 100%;
+  padding: 8px 12px 8px 60px;
   /* 왼쪽 패딩: 아이콘 공간 확보 */
   border: 1px solid #ccc;
   border-radius: 8px;
@@ -110,17 +123,20 @@
 .post-list {
   display: flex;
   flex-direction: column;
-  padding-top: 60px;
-  margin-bottom: 90px;
+  margin-top: 90px;
+  padding-bottom: 90px;
 }
 
 .item-card {
   display: flex;
   padding: 12px 16px;
   gap: 12px;
-  border-top: 1px solid #d9d9d9;
-  border-bottom: 1px solid #d9d9d9;
+  border-top: 1px solid var(--color-light-main);
   position: relative;
+}
+
+.item-card:last-child {
+  border-bottom: 1px solid var(--color-light-main);
 }
 
 .item-img {
@@ -146,7 +162,7 @@
   width: 88px;
   height: 17px;
   border-radius: 8.5px;
-  margin: 10px 10px;
+  margin: 10px 10px 10px 0;
   background-color: var(--color-deep-main);
   color: #fff;
 }
@@ -158,6 +174,7 @@
   margin: 10px 10px;
   background-color: var(--color-mint);
   color: #fff;
+  margin: 10px 10px 10px 0;
 }
 
 .age {
@@ -202,7 +219,6 @@
 .title {
   font-size: 17px;
   font-weight: 600;
-  margin-top: 60px;
 }
 
 .main {
@@ -249,6 +265,7 @@
   z-index: 20;
   /* nav보다 위에 오게 */
   pointer-events: auto;
+  cursor: pointer;
 }
 
 .plus_bg {


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->


## ✅ 작업 내용
<!-- 작업에 대한 설명을 적어주세요 -->
홈 화면, 홈 검색 화면, 게시글 없는 홈 화면의 css를 피그마 시안과 유사하게 수정했습니다.

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요하다면 스크린샷을 첨부해주세요 -->
<img width="378" height="823" alt="image" src="https://github.com/user-attachments/assets/757601b4-81e8-4247-8571-d24055d21da4" />
<img width="374" height="818" alt="image" src="https://github.com/user-attachments/assets/7127151f-6be2-4306-8a05-a97af637357a" />
<img width="379" height="820" alt="image" src="https://github.com/user-attachments/assets/c2ea29e9-26ba-4e1c-b194-0710beb39934" />


## 💬 리뷰 참고 사항
<!-- 코드 리뷰 시 유의해야 할 점을 적어주세요 -->
- 메인 페이지 카테고리 버튼이 해상도에 따라 잘리기도 하는 것 같습니다.
- 헤더 부분의 position을 fixed로 변경함에 따라 css가 깨지는 경우도 있을 것 같습니다. 수정 필요할 경우 언제든 말씀해주세요!