### PR TITLE
fix: 거래 완료 모달 신청자에게 한 번만 보이게 수정

### DIFF
--- a/chat/static/chat/chat.css
+++ b/chat/static/chat/chat.css
@@ -10,7 +10,7 @@ label {
   -webkit-tap-highlight-color: rgba(255, 255, 255, 0);
 }
 
-.darken {
+.darken, .success-darken {
   position: fixed;
   right: 0;
   top: 0;
@@ -76,7 +76,7 @@ label {
   border-top: 1px dashed #c4f2ff;
 }
 
-.complete-modal-bottom {
+#complete-form {
   display: flex;
   justify-content: space-evenly;
   align-items: center;

--- a/chat/static/chat/js/chat.js
+++ b/chat/static/chat/js/chat.js
@@ -9,17 +9,12 @@ const ok = document.getElementById("ok");
 const preview = document.querySelector(".img-preview");
 const previewDarken = document.querySelector(".preview-darken");
 
-const successModal = document.querySelector(".success-modal");
-const check = document.getElementById("check");
-
 console.log("isCompleted 값:", isCompleted);
 
 // 모달창 닫는 함수
-function closeAll() {
+function closeCompleteModal() {
   completeModal.classList.add("hidden");
-  if (successModal.classList.contains("hidden")) {
-    darken.classList.add("hidden");
-  }
+  darken.classList.add("hidden");
 }
 
 // 사진 미리보기 함수
@@ -41,9 +36,14 @@ function renderPreview(photo) {
 
 // 거래완료 버튼 누르면 화면 어두워지고 모달창 뜸
 completeBtn.addEventListener("click", (e) => {
-  if (isCompleted) return;
+  console.log("거래 완료 버튼 클릭됨");
+  if (isCompleted) {
+    console.log("이미 완료된 거래입니다.");
+    return;
+  }
 
   e.stopPropagation();
+  console.log("모달 열기 시도 중...");
   darken.classList.remove("hidden");
   completeModal.classList.remove("hidden");
 });
@@ -54,21 +54,12 @@ completeModal.addEventListener("click", (e) => {
 });
 
 // 취소 버튼 누르거나, 화면 다른 부분 누르면 모달창 닫힘
-document.addEventListener("click", closeAll);
-cancel.addEventListener("click", closeAll);
+document.addEventListener("click", closeCompleteModal);
+cancel.addEventListener("click", closeCompleteModal);
 
-// ✅ 네 버튼을 눌렀을 때 기존 모달창 닫고 거래 완료 모달창 열기
+// ✅ 네 버튼을 눌렀을 때도 모달창 닫기
 ok.addEventListener("click", () => {
-  completeModal.classList.add("hidden"); // 모달 닫기
-
-  // 거래 완료 모달 열기
-  successModal.classList.remove("hidden");
-});
-
-// 폼은 거래 완료 모달의 확인 버튼 눌러야 submit 됨 (다른 버튼으로 안 닫히게)
-check.addEventListener("click", () => {
-  successModal.classList.add("hidden");
-  darken.classList.add("hidden");
+  closeCompleteModal(); // 모달 닫기
 });
 
 // 사진 여러 장 업로드 금지
@@ -83,7 +74,6 @@ imgInput.addEventListener("change", () => {
   renderPreview(photos[0]);
 });
 
-// 입력 없을 경우 전송되지 않게 (여전히 전송됨.. 해결해야함) => 해결 완료!
 document.addEventListener("DOMContentLoaded", () => {
   const form = document.querySelector(".chat-input");
   const textInput = document.getElementById("text-input");
@@ -132,6 +122,26 @@ document.addEventListener("DOMContentLoaded", () => {
   if (isCompleted) {
     completeBtn.style.backgroundColor = "#8A8A8A"; // 거래완료 시 회색 버튼 됨
   }
+
+  // 거래 신청자가 최초로 들어왔을 때 거래 완료 모달
+  const successModal = document.querySelector(".success-modal");
+  const check = document.getElementById("check");
+  const successDarken = document.querySelector(".success-darken");
+
+  const threadId = document.querySelector(".main-container").dataset.threadId;
+  const modalKey = `${threadId}_modal_shown`;
+
+  // 만약 localStorage에 채팅방 모달 키가 없다면 거래 완료 모달 띄움 (최초 한 번만)
+  if (!localStorage.getItem(modalKey)) {
+    successModal.classList.remove("hidden");
+    successDarken.classList.remove("hidden");
+  }
+  
+  check.addEventListener("click", () => {
+    localStorage.setItem(modalKey, "true");
+    successModal.classList.add("hidden");
+    successDarken.classList.add("hidden");
+  });
 });
 
 // 리다이렉트 시 최신 채팅으로 스크롤 이동
@@ -140,19 +150,4 @@ window.addEventListener("DOMContentLoaded", () => {
     const anchor = document.getElementById("scroll-anchor");
     anchor?.scrollIntoView({ behavior: "auto" });
   }, 50); // 일부러 지연시켜서 타이밍 어긋나지 않게
-});
-
-
-
-completeBtn.addEventListener("click", (e) => {
-  console.log("거래 완료 버튼 클릭됨");
-  if (isCompleted) {
-    console.log("이미 완료된 거래입니다.");
-    return;
-  }
-
-  e.stopPropagation();
-  console.log("모달 열기 시도 중...");
-  darken.classList.remove("hidden");
-  completeModal.classList.remove("hidden");
 });

--- a/chat/templates/chat/chat.html
+++ b/chat/templates/chat/chat.html
@@ -18,22 +18,24 @@
     <div class="complete-modal hidden">
       <p>거래를 완료하시겠어요?</p>
       <div class="x-divide"></div>
-      <div class="complete-modal-bottom">
-        <button type="button" id="cancel">아니오</button>
-        <div class="y-divide"></div>
-        <button type="button" id="ok">네</button>
-      </div>
-    </div>
-
-    <div class="success-modal hidden">
       <form method="POST" action="{% url 'chat:complete_trade' thread.thread_id %}" id="complete-form">
         {% csrf_token %}
-        <p>🎉거래가 완료 되었습니다!</p>
-        <button type="submit" id="check">확인</button>
+        <button type="button" id="cancel">아니오</button>
+        <div class="y-divide"></div>
+        <button type="submit" id="ok">네</button>
       </form>
+      </div>
     </div>
-
     <div class="darken hidden"></div>
+    {% if is_completed %}
+      {% if not is_receiver %}
+      <div class="success-modal hidden">
+        <p>🎉거래가 완료 되었습니다!</p>
+        <button type="button" id="check">확인</button>
+      </div>
+      <div class="success-darken hidden"></div>
+      {% endif %}
+    {% endif %}
 
     <!-- 이미지 미리보기 -->
     <div class="img-preview hidden">
@@ -51,7 +53,8 @@
       </a>
     </div>
 
-    <div class="main-container">
+    <!-- 신청자 최초 열람 여부 확인을 위해 임의로 집어넣었습니다 -->
+    <div class="main-container" data-thread-id="{{ thread.thread_id }}">
     <!-- 거래 완료 상태 확인을 위해 임의로 집어넣었습니다 -->
     <div id="is-completed" data-completed="{{ is_completed }}"></div>
     <div class="complete-bar">
@@ -61,7 +64,7 @@
           <button class="complete-btn" disabled>거래 완료</button>
         {% else %}
           <div class="complete-desc">거래가 끝나셨다면 버튼을 눌러 완료해 주세요.</div>
-          <button id="complete-btn">거래 완료</button>
+          <button class="complete-btn">거래 완료</button>
         {% endif %}
       {% else %}
         <!-- 신청자 입장 -->


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->


## ✅ 작업 내용
<!-- 작업에 대한 설명을 적어주세요 -->
작성자가 거래 완료 누르면, 신청자에게 거래 완료 모달이 최초 한 번만 뜨게 수정했습니다.
- 작성자에게 뜨는 모달에서 네를 누르면 거래 완료 submit이 됩니다.
- 신청자에게 뜨는 모달에서 확인을 누르면 thread_id가 localStorage에 저장이 됩니다.
(localStorage는 브라우저 닫아도 저장되는 걸로 알고 있습니다!)

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요하다면 스크린샷을 첨부해주세요 -->
<img width="422" height="746" alt="image" src="https://github.com/user-attachments/assets/1766d421-0d5e-489a-8cf4-0143b48954f5" />
<img width="421" height="744" alt="image" src="https://github.com/user-attachments/assets/8b4e4fc6-d359-48ba-9d12-2dce32128bd3" />


## 💬 리뷰 참고 사항
<!-- 코드 리뷰 시 유의해야 할 점을 적어주세요 -->
오류 있으면 언제든 말씀해주세요!